### PR TITLE
add alternate implementations of error_chain that do not require types section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ define an `errors` module and inside it call `error_chain!`:
 error_chain! {
     // The type defined for this error. These are the conventional
     // and recommended names, but they can be arbitrarily chosen.
+	// It is also possible to leave this block out entirely, or
+	// leave it empty, and these names will be used automatically.
     types {
         Error, ErrorKind, ChainErr, Result;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@
 //! error_chain! {
 //!     // The type defined for this error. These are the conventional
 //!     // and recommended names, but they can be arbitrarily chosen.
+//!     // It is also possible to leave this block out entirely, or
+//!     // leave it empty, and these names will be used automatically.
 //!     types {
 //!         Error, ErrorKind, ChainErr, Result;
 //!     }
@@ -256,6 +258,77 @@ mod quick_error;
 
 #[macro_export]
 macro_rules! error_chain {
+    (
+        links {
+            $( $link_error_path:path, $link_kind_path:path, $link_variant:ident;  ) *
+        }
+
+        foreign_links {
+            $( $foreign_link_error_path:path, $foreign_link_variant:ident,
+               $foreign_link_desc:expr;  ) *
+        }
+
+        errors {
+            $( $error_chunks:tt ) *
+        }
+
+    ) => (
+        error_chain! {
+            types {
+                Error, ErrorKind, ChainErr, Result;
+            }
+
+            links {
+                $( $link_error_path:path, $link_kind_path:path, $link_variant:ident;  ) *
+            }
+
+            foreign_links {
+                $( $foreign_link_error_path:path, $foreign_link_variant:ident,
+                   $foreign_link_desc:expr;  ) *
+            }
+
+            errors {
+                $( $error_chunks:tt ) *
+            }
+        }
+    );
+    (
+        types {
+        }
+
+        links {
+            $( $link_error_path:path, $link_kind_path:path, $link_variant:ident;  ) *
+        }
+
+        foreign_links {
+            $( $foreign_link_error_path:path, $foreign_link_variant:ident,
+               $foreign_link_desc:expr;  ) *
+        }
+
+        errors {
+            $( $error_chunks:tt ) *
+        }
+
+    ) => (
+        error_chain! {
+            types {
+                Error, ErrorKind, ChainErr, Result;
+            }
+
+            links {
+                $( $link_error_path:path, $link_kind_path:path, $link_variant:ident;  ) *
+            }
+
+            foreign_links {
+                $( $foreign_link_error_path:path, $foreign_link_variant:ident,
+                   $foreign_link_desc:expr;  ) *
+            }
+
+            errors {
+                $( $error_chunks:tt ) *
+            }
+        }
+    );
     (
         types {
             $error_name:ident, $error_kind_name:ident,
@@ -488,7 +561,6 @@ use std::iter::Iterator;
 pub struct ErrorChainIter<'a>(pub Option<&'a StdError>);
 
 impl<'a> Iterator for ErrorChainIter<'a> {
-
     type Item = &'a StdError;
 
     fn next<'b>(&'b mut self) -> Option<&'a StdError> {
@@ -497,8 +569,7 @@ impl<'a> Iterator for ErrorChainIter<'a> {
                 self.0 = e.cause();
                 Some(e)
             }
-            None => None
+            None => None,
         }
     }
 }
-

--- a/src/quick_error.rs
+++ b/src/quick_error.rs
@@ -16,7 +16,7 @@ macro_rules! quick_error {
             items [] buf []
             queue [ $($chunks)* ]);
     };
-    // Queue is empty, can do the work
+// Queue is empty, can do the work
     (SORT [enum $name:ident $( #[$meta:meta] )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -55,7 +55,7 @@ macro_rules! quick_error {
             quick_error!(ERROR_CHECK $imode $($ifuncs)*);
         )*
     };
-    // Add meta to buffer
+// Add meta to buffer
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -68,7 +68,7 @@ macro_rules! quick_error {
             buf [$( #[$bmeta] )* #[$qmeta] ]
             queue [$( $tail )*]);
     };
-    // Add ident to buffer
+// Add ident to buffer
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -82,7 +82,7 @@ macro_rules! quick_error {
             buf [$(#[$bmeta])* => $qitem : UNIT [ ] ]
             queue [$( $tail )*]);
     };
-    // Flush buffer on meta after ident
+// Flush buffer on meta after ident
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -100,7 +100,7 @@ macro_rules! quick_error {
             buf [ #[$qmeta] ]
             queue [$( $tail )*]);
     };
-    // Add tuple enum-variant
+// Add tuple enum-variant
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -114,7 +114,7 @@ macro_rules! quick_error {
             queue [$( $tail )*]
         );
     };
-    // Add struct enum-variant - e.g. { descr: &'static str }
+// Add struct enum-variant - e.g. { descr: &'static str }
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -127,7 +127,7 @@ macro_rules! quick_error {
             buf [$( #[$bmeta] )* => $bitem: STRUCT [$( $qvar:$qtyp ),*] ]
             queue [$( $tail )*]);
     };
-    // Add struct enum-variant, with excess comma - e.g. { descr: &'static str, }
+// Add struct enum-variant, with excess comma - e.g. { descr: &'static str, }
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -140,7 +140,7 @@ macro_rules! quick_error {
             buf [$( #[$bmeta] )* => $bitem: STRUCT [$( $qvar:$qtyp ),*] ]
             queue [$( $tail )*]);
     };
-    // Add braces and flush always on braces
+// Add braces and flush always on braces
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -155,7 +155,7 @@ macro_rules! quick_error {
             buf [ ]
             queue [$( $tail )*]);
     };
-    // Flush buffer on double ident
+// Flush buffer on double ident
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -170,7 +170,7 @@ macro_rules! quick_error {
             buf [ => $qitem : UNIT [ ] ]
             queue [$( $tail )*]);
     };
-    // Flush buffer on end
+// Flush buffer on end
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -185,7 +185,7 @@ macro_rules! quick_error {
             buf [ ]
             queue [ ]);
     };
-    // Public enum (Queue Empty)
+// Public enum (Queue Empty)
     (ENUM_DEFINITION [pub enum $name:ident $( #[$meta:meta] )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
@@ -199,7 +199,7 @@ macro_rules! quick_error {
             )*
         }
     };
-    // Private enum (Queue Empty)
+// Private enum (Queue Empty)
     (ENUM_DEFINITION [enum $name:ident $( #[$meta:meta] )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
@@ -213,7 +213,7 @@ macro_rules! quick_error {
             )*
         }
     };
-    // Unit variant
+// Unit variant
     (ENUM_DEFINITION [$( $def:tt )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
@@ -226,7 +226,7 @@ macro_rules! quick_error {
             queue [ $($queue)* ]
         );
     };
-    // Tuple variant
+// Tuple variant
     (ENUM_DEFINITION [$( $def:tt )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
@@ -239,7 +239,7 @@ macro_rules! quick_error {
             queue [ $($queue)* ]
         );
     };
-    // Struct variant
+// Struct variant
     (ENUM_DEFINITION [$( $def:tt )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
@@ -277,35 +277,35 @@ macro_rules! quick_error {
                 }
             }
         }
-        /*#[allow(unused)]
-        impl ::std::error::Error for $name {
-            fn description(&self) -> &str {
-                match *self {
-                    $(
-                        quick_error!(ITEM_PATTERN
-                            $name $item: $imode [$( ref $var ),*]
-                        ) => {
-                            quick_error!(FIND_DESCRIPTION_IMPL
-                                $item: $imode self fmt [$( $var ),*]
-                                {$( $funcs )*})
-                        }
-                    )*
-                }
-            }
-            fn cause(&self) -> Option<&::std::error::Error> {
-                match *self {
-                    $(
-                        quick_error!(ITEM_PATTERN
-                            $name $item: $imode [$( ref $var ),*]
-                        ) => {
-                            quick_error!(FIND_CAUSE_IMPL
-                                $item: $imode [$( $var ),*]
-                                {$( $funcs )*})
-                        }
-                    )*
-                }
-            }
-        }*/
+// #[allow(unused)]
+// impl ::std::error::Error for $name {
+// fn description(&self) -> &str {
+// match *self {
+// $(
+// quick_error!(ITEM_PATTERN
+// $name $item: $imode [$( ref $var ),*]
+// ) => {
+// quick_error!(FIND_DESCRIPTION_IMPL
+// $item: $imode self fmt [$( $var ),*]
+// {$( $funcs )*})
+// }
+// )*
+// }
+// }
+// fn cause(&self) -> Option<&::std::error::Error> {
+// match *self {
+// $(
+// quick_error!(ITEM_PATTERN
+// $name $item: $imode [$( ref $var ),*]
+// ) => {
+// quick_error!(FIND_CAUSE_IMPL
+// $item: $imode [$( $var ),*]
+// {$( $funcs )*})
+// }
+// )*
+// }
+// }
+// }
         #[allow(unused)]
         impl $name {
             pub fn description(&self) -> &str {
@@ -493,10 +493,10 @@ macro_rules! quick_error {
     ) => {
         $name::$item {$( ref $var ),*}
     };
-    // This one should match all allowed sequences in "funcs" but not match
-    // anything else.
-    // This is to contrast FIND_* clauses which just find stuff they need and
-    // skip everything else completely
+// This one should match all allowed sequences in "funcs" but not match
+// anything else.
+// This is to contrast FIND_* clauses which just find stuff they need and
+// skip everything else completely
     (ERROR_CHECK $imode:tt display($self_:tt) -> ($( $exprs:tt )*) $( $tail:tt )*)
     => { quick_error!(ERROR_CHECK $imode $($tail)*); };
     (ERROR_CHECK $imode:tt display($pattern: expr) $( $tail:tt )*)
@@ -516,6 +516,6 @@ macro_rules! quick_error {
     (ERROR_CHECK STRUCT from($fvar:ident: $ftyp:ty) -> {$( $v:ident: $e:expr ),*} $( $tail:tt )*)
     => { quick_error!(ERROR_CHECK STRUCT $($tail)*); };
     (ERROR_CHECK $imode:tt ) => {};
-    // Utility functions
+// Utility functions
     (IDENT $ident:ident) => { $ident }
 }

--- a/src/quick_error.rs
+++ b/src/quick_error.rs
@@ -16,7 +16,7 @@ macro_rules! quick_error {
             items [] buf []
             queue [ $($chunks)* ]);
     };
-// Queue is empty, can do the work
+    // Queue is empty, can do the work
     (SORT [enum $name:ident $( #[$meta:meta] )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -55,7 +55,7 @@ macro_rules! quick_error {
             quick_error!(ERROR_CHECK $imode $($ifuncs)*);
         )*
     };
-// Add meta to buffer
+    // Add meta to buffer
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -68,7 +68,7 @@ macro_rules! quick_error {
             buf [$( #[$bmeta] )* #[$qmeta] ]
             queue [$( $tail )*]);
     };
-// Add ident to buffer
+    // Add ident to buffer
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -82,7 +82,7 @@ macro_rules! quick_error {
             buf [$(#[$bmeta])* => $qitem : UNIT [ ] ]
             queue [$( $tail )*]);
     };
-// Flush buffer on meta after ident
+    // Flush buffer on meta after ident
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -100,7 +100,7 @@ macro_rules! quick_error {
             buf [ #[$qmeta] ]
             queue [$( $tail )*]);
     };
-// Add tuple enum-variant
+    // Add tuple enum-variant
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -114,7 +114,7 @@ macro_rules! quick_error {
             queue [$( $tail )*]
         );
     };
-// Add struct enum-variant - e.g. { descr: &'static str }
+    // Add struct enum-variant - e.g. { descr: &'static str }
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -127,7 +127,7 @@ macro_rules! quick_error {
             buf [$( #[$bmeta] )* => $bitem: STRUCT [$( $qvar:$qtyp ),*] ]
             queue [$( $tail )*]);
     };
-// Add struct enum-variant, with excess comma - e.g. { descr: &'static str, }
+    // Add struct enum-variant, with excess comma - e.g. { descr: &'static str, }
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -140,7 +140,7 @@ macro_rules! quick_error {
             buf [$( #[$bmeta] )* => $bitem: STRUCT [$( $qvar:$qtyp ),*] ]
             queue [$( $tail )*]);
     };
-// Add braces and flush always on braces
+    // Add braces and flush always on braces
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -155,7 +155,7 @@ macro_rules! quick_error {
             buf [ ]
             queue [$( $tail )*]);
     };
-// Flush buffer on double ident
+    // Flush buffer on double ident
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -170,7 +170,7 @@ macro_rules! quick_error {
             buf [ => $qitem : UNIT [ ] ]
             queue [$( $tail )*]);
     };
-// Flush buffer on end
+    // Flush buffer on end
     (SORT [$( $def:tt )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
@@ -185,7 +185,7 @@ macro_rules! quick_error {
             buf [ ]
             queue [ ]);
     };
-// Public enum (Queue Empty)
+    // Public enum (Queue Empty)
     (ENUM_DEFINITION [pub enum $name:ident $( #[$meta:meta] )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
@@ -199,7 +199,7 @@ macro_rules! quick_error {
             )*
         }
     };
-// Private enum (Queue Empty)
+    // Private enum (Queue Empty)
     (ENUM_DEFINITION [enum $name:ident $( #[$meta:meta] )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
@@ -213,7 +213,7 @@ macro_rules! quick_error {
             )*
         }
     };
-// Unit variant
+    // Unit variant
     (ENUM_DEFINITION [$( $def:tt )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
@@ -226,7 +226,7 @@ macro_rules! quick_error {
             queue [ $($queue)* ]
         );
     };
-// Tuple variant
+    // Tuple variant
     (ENUM_DEFINITION [$( $def:tt )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
@@ -239,7 +239,7 @@ macro_rules! quick_error {
             queue [ $($queue)* ]
         );
     };
-// Struct variant
+    // Struct variant
     (ENUM_DEFINITION [$( $def:tt )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
@@ -277,35 +277,35 @@ macro_rules! quick_error {
                 }
             }
         }
-// #[allow(unused)]
-// impl ::std::error::Error for $name {
-// fn description(&self) -> &str {
-// match *self {
-// $(
-// quick_error!(ITEM_PATTERN
-// $name $item: $imode [$( ref $var ),*]
-// ) => {
-// quick_error!(FIND_DESCRIPTION_IMPL
-// $item: $imode self fmt [$( $var ),*]
-// {$( $funcs )*})
-// }
-// )*
-// }
-// }
-// fn cause(&self) -> Option<&::std::error::Error> {
-// match *self {
-// $(
-// quick_error!(ITEM_PATTERN
-// $name $item: $imode [$( ref $var ),*]
-// ) => {
-// quick_error!(FIND_CAUSE_IMPL
-// $item: $imode [$( $var ),*]
-// {$( $funcs )*})
-// }
-// )*
-// }
-// }
-// }
+        /*#[allow(unused)]
+        impl ::std::error::Error for $name {
+            fn description(&self) -> &str {
+                match *self {
+                    $(
+                        quick_error!(ITEM_PATTERN
+                            $name $item: $imode [$( ref $var ),*]
+                        ) => {
+                            quick_error!(FIND_DESCRIPTION_IMPL
+                                $item: $imode self fmt [$( $var ),*]
+                                {$( $funcs )*})
+                        }
+                    )*
+                }
+            }
+            fn cause(&self) -> Option<&::std::error::Error> {
+                match *self {
+                    $(
+                        quick_error!(ITEM_PATTERN
+                            $name $item: $imode [$( ref $var ),*]
+                        ) => {
+                            quick_error!(FIND_CAUSE_IMPL
+                                $item: $imode [$( $var ),*]
+                                {$( $funcs )*})
+                        }
+                    )*
+                }
+            }
+        }*/
         #[allow(unused)]
         impl $name {
             pub fn description(&self) -> &str {
@@ -331,7 +331,9 @@ macro_rules! quick_error {
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { display($self_:tt) -> ($( $exprs:tt )*) $( $tail:tt )*}
     ) => {
-        |quick_error!(IDENT $self_): &$name, f: &mut ::std::fmt::Formatter| { write!(f, $( $exprs )*) }
+        |quick_error!(IDENT $self_): &$name, f: &mut ::std::fmt::Formatter| {
+            write!(f, $( $exprs )*)
+        }
     };
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { display($pattern:expr) $( $tail:tt )*}
@@ -493,10 +495,10 @@ macro_rules! quick_error {
     ) => {
         $name::$item {$( ref $var ),*}
     };
-// This one should match all allowed sequences in "funcs" but not match
-// anything else.
-// This is to contrast FIND_* clauses which just find stuff they need and
-// skip everything else completely
+    // This one should match all allowed sequences in "funcs" but not match
+    // anything else.
+    // This is to contrast FIND_* clauses which just find stuff they need and
+    // skip everything else completely
     (ERROR_CHECK $imode:tt display($self_:tt) -> ($( $exprs:tt )*) $( $tail:tt )*)
     => { quick_error!(ERROR_CHECK $imode $($tail)*); };
     (ERROR_CHECK $imode:tt display($pattern: expr) $( $tail:tt )*)
@@ -516,6 +518,6 @@ macro_rules! quick_error {
     (ERROR_CHECK STRUCT from($fvar:ident: $ftyp:ty) -> {$( $v:ident: $e:expr ),*} $( $tail:tt )*)
     => { quick_error!(ERROR_CHECK STRUCT $($tail)*); };
     (ERROR_CHECK $imode:tt ) => {};
-// Utility functions
+    // Utility functions
     (IDENT $ident:ident) => { $ident }
 }


### PR DESCRIPTION
I added two alternate implementations of the `error_chain` macro. One allows for an empty `types` block, the other leaves the `types` block out entirely. This should fix #5. I also ran rustfmt on lib.rs and quick_error.rs.