### PR TITLE
Allow missing sections

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,40 +316,8 @@ mod quick_error;
 
 #[macro_export]
 macro_rules! error_chain {
-    (
-        links {
-            $( $link_error_path:path, $link_kind_path:path, $link_variant:ident;  ) *
-        }
 
-        foreign_links {
-            $( $foreign_link_error_path:path, $foreign_link_variant:ident,
-               $foreign_link_desc:expr;  ) *
-        }
-
-        errors {
-            $( $error_chunks:tt ) *
-        }
-
-    ) => (
-        error_chain! {
-            types {
-                Error, ErrorKind, ChainErr, Result;
-            }
-
-            links {
-                $( $link_error_path, $link_kind_path, $link_variant;  ) *
-            }
-
-            foreign_links {
-                $( $foreign_link_error_path, $foreign_link_variant,
-                   $foreign_link_desc;  ) *
-            }
-
-            errors {
-                $( $error_chunks ) *
-            }
-        }
-    );
+    // Provide default for types block
     (
         types {
         }
@@ -387,6 +355,7 @@ macro_rules! error_chain {
             }
         }
     );
+
     (
         types {
             $error_name:ident, $error_kind_name:ident,
@@ -619,6 +588,54 @@ macro_rules! error_chain {
 
         pub type $result_name<T> = ::std::result::Result<T, $error_name>;
     };
+
+    // Allow missing sections
+    // There should only ever be zero or one of each section, but there's currently no
+    // way to express that in a macro
+    (
+
+        $( types {
+            $(
+                $error_name:ident, $error_kind_name:ident,
+                $chain_error_name:ident, $result_name:ident;
+            ) *
+        } ) *
+
+        $( links {
+            $( $link_error_path:path, $link_kind_path:path, $link_variant:ident;  ) *
+        } ) *
+
+        $( foreign_links {
+            $( $foreign_link_error_path:path, $foreign_link_variant:ident,
+               $foreign_link_desc:expr;  ) *
+        } ) *
+
+        $( errors {
+            $( $error_chunks:tt ) *
+        } ) *
+    ) => (
+        error_chain! {
+            types {
+                $( $(
+                    $error_name, $error_kind_name,
+                    $chain_error_name, $result_name;
+                ) * ) *
+            }
+
+            links {
+                $( $( $link_error_path, $link_kind_path, $link_variant;  ) * ) *
+            }
+
+            foreign_links {
+                $( $( $foreign_link_error_path, $foreign_link_variant,
+                   $foreign_link_desc;  ) * ) *
+            }
+
+            errors {
+                $( $( $error_chunks ) * ) *
+            }
+        }
+    );
 }
 
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -76,6 +76,34 @@ fn smoke_test_5() {
     }
 }
 
+#[test]
+fn smoke_test_6() {
+    error_chain! {
+        errors {
+            HttpStatus(e: u32) {
+                description("http request returned an unsuccessful status code")
+                display("http request returned an unsuccessful status code: {}", e)
+            }
+        }
+    }
+}
+
+#[test]
+fn smoke_test_7() {
+    error_chain! {
+        types { }
+
+        foreign_links { }
+
+        errors {
+            HttpStatus(e: u32) {
+                description("http request returned an unsuccessful status code")
+                display("http request returned an unsuccessful status code: {}", e)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod foreign_link_test {
 


### PR DESCRIPTION
Fix #6 

Unfortunately, I wasn't able to come up with a simple way to match zero or one instances of a pattern. Because of this, it's possible to write a few pathological errors that will cause infinite recursion rather than a more helpful description.

Example:
```

#[test]
fn smoke_test_9() {
    error_chain! {
        types {
            Error, ErrorKind, ChainErr, Result;
        }
        types {
            Error, ErrorKind, ChainErr, Result;
        }

        foreign_links { }

        errors {
            HttpStatus(e: u32) {
                description("http request returned an unsuccessful status code")
                display("http request returned an unsuccessful status code: {}", e)
            }
        }
    }
}
```
Because there are multiple `types` declarations, they are both combined into a single `types` declaration which looks like `types { Error, ErrorKind, ChainErr, Result; Error, ErrorKind, ChainErr, Result; }`, which doesn't match any of the existing rules except the one that produced it.

It is necessary for there to be a rule like this that matches zero or one type blocks with zero or one entry sections, so I don't see how to avoid matching on more than one type block or more than one entry section.

Perhaps an RFC for a macro_rules `?` is in order? Do you know why this was excluded to begin with? It seems like a natural extension of `*` and `+`.