### PR TITLE
Fixup matching, disallow repeating "types" (closes #23)

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -105,6 +105,26 @@ fn smoke_test_7() {
 }
 
 #[test]
+fn smoke_test_8() {
+    error_chain! {
+        types { }
+
+        links { }
+        links { }
+
+        foreign_links { }
+        foreign_links { }
+
+        errors {
+            FileNotFound
+        }
+        errors {
+            AccessDenied
+        }
+    }
+}
+
+#[test]
 fn empty() {
     error_chain! { }
 }


### PR DESCRIPTION
It is actually not a problem to have repeating instances of `links`,
`foreign_links` and `errors`, the items will just be appended.

To handle the zero-or-one rule for `types`, we can get away with just
one new matching rule, because there are three cases (no types, empty
types, and fully specified types).