### PR TITLE
Fix tests on stable/beta (closes #12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ addons:
     - libelf-dev
     - libdw-dev
 rust:
+- stable
+- beta
 - nightly
 before_script:
 - |

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,7 +15,7 @@ fn smoke_test_1() {
         foreign_links { }
 
         errors { }
-    }
+    };
 }
 
 #[test]
@@ -28,7 +28,7 @@ fn smoke_test_2() {
         foreign_links { }
 
         errors { }
-    }
+    };
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn smoke_test_3() {
         foreign_links { }
 
         errors { }
-    }
+    };
 }
 
 #[test]
@@ -55,7 +55,7 @@ fn smoke_test_4() {
                 display("http request returned an unsuccessful status code: {}", e)
             }
         }
-    }
+    };
 }
 
 #[test]
@@ -73,7 +73,7 @@ fn smoke_test_5() {
                 display("http request returned an unsuccessful status code: {}", e)
             }
         }
-    }
+    };
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn smoke_test_6() {
                 display("http request returned an unsuccessful status code: {}", e)
             }
         }
-    }
+    };
 }
 
 #[test]
@@ -101,12 +101,12 @@ fn smoke_test_7() {
                 display("http request returned an unsuccessful status code: {}", e)
             }
         }
-    }
+    };
 }
 
 #[test]
 fn empty() {
-    error_chain! { }
+    error_chain! { };
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Apparently, if the macro invocation is the last "expression" in the function block, the parser expects an expression and will not let the macro expand to anything else.  Appending a semicolon will disabuse it of that notion.

The breakage only applies to error_chain! usage inside functions, which is probably not relevant other than in these tests.

Seems to be fixed in nightly 1.12 anyway.