### PR TITLE
only deploy docs when tagged (fix #18)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,11 @@ script:
   travis-cargo build &&
   travis-cargo test &&
   travis-cargo --only nightly doc
-after_success:
-- travis-cargo --only nightly doc-upload
+deploy:
+  provider: script
+  script: travis-cargo --only nightly doc-upload
+  on:
+    tags: true
 env:
   global:
   - TRAVIS_CARGO_NIGHTLY_FEATURE=""


### PR DESCRIPTION
Docs are still built (not uploaded) when untagged, but this might reveal bugs so I didn't change it.

I also don't have any means of testing this right now but I more or less copied from the travis docs so it is supposed to work.