### PR TITLE
add :: to the paths in error_chain! docs, so they'd work even inside a submodule.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,8 @@
 //!     //
 //!     // This section can be empty.
 //!     links {
-//!         rustup_dist::Error, rustup_dist::ErrorKind, Dist;
-//!         rustup_utils::Error, rustup_utils::ErrorKind, Utils;
+//!         ::rustup_dist::Error, rustup_dist::ErrorKind, Dist;
+//!         ::rustup_utils::Error, rustup_utils::ErrorKind, Utils;
 //!     }
 //!
 //!     // Automatic conversions between this error chain and other
@@ -145,7 +145,7 @@
 //!     //
 //!     // This section can be empty.
 //!     foreign_links {
-//!         temp::Error, Temp;
+//!         ::temp::Error, Temp;
 //!     }
 //!
 //!     // Define additional `ErrorKind` variants. The syntax here is


### PR DESCRIPTION
This confused me. Admittedly the module & path system is something that Rust users using this crate are expected to know and understand, but this helps a bit those who don't, and many are just going to copy-paste the code from the docs for a test run, so it helps there too.
