### PR TITLE
make backtrace a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,7 @@ repository = "https://github.com/brson/error-chain"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-backtrace = "0.2.1"
+backtrace = { version = "0.2.1", optional = true }
+
+[features]
+default = [ "backtrace" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,9 +306,14 @@
 //! [error-type]: https://github.com/DanielKeep/rust-error-type
 //! [quick-error]: https://github.com/tailhook/quick-error
 
+#[cfg(feature="backtrace")]
 extern crate backtrace;
 
+#[cfg(feature="backtrace")]
 pub use backtrace::Backtrace;
+
+#[cfg(not(feature="backtrace"))]
+pub type Backtrace = ();
 
 mod quick_error;
 
@@ -678,9 +683,15 @@ impl<'a> Iterator for ErrorChainIter<'a> {
 /// Returns a backtrace of the current call stack if `RUST_BACKTRACE`
 /// is set to anything but ``0``, and `None` otherwise.  This is used
 /// in the generated error implementations.
+#[cfg(feature = "backtrace")]
 pub fn make_backtrace() -> Option<Arc<Backtrace>> {
     match std::env::var_os("RUST_BACKTRACE") {
         Some(ref val) if val != "0" => Some(Arc::new(Backtrace::new())),
         _ => None
     }
+}
+
+#[cfg(not(feature = "backtrace"))]
+pub fn make_backtrace() -> Option<Arc<Backtrace>> {
+    None
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,12 +309,6 @@
 #[cfg(feature="backtrace")]
 extern crate backtrace;
 
-#[cfg(feature="backtrace")]
-pub use backtrace::Backtrace;
-
-#[cfg(not(feature="backtrace"))]
-pub type Backtrace = ();
-
 mod quick_error;
 
 #[macro_export]
@@ -349,7 +343,7 @@ macro_rules! error_chain {
         #[derive(Debug)]
         pub struct $error_name(pub $error_kind_name,
                                pub (Option<Box<::std::error::Error + Send>>,
-                                    Option<::std::sync::Arc<$crate::Backtrace>>));
+                                    $crate::BacktraceHolder));
 
         #[allow(unused)]
         impl $error_name {
@@ -365,6 +359,7 @@ macro_rules! error_chain {
                 $crate::ErrorChainIter(Some(self))
             }
 
+            #[cfg(feature="backtrace")]
             pub fn backtrace(&self) -> Option<&$crate::Backtrace> {
                 (self.1).1.as_ref().map(|v| &**v)
             }
@@ -518,7 +513,7 @@ macro_rules! error_chain {
         // machinery to make it work.
         fn backtrace_from_box(mut e: Box<::std::error::Error + Send + 'static>)
                               -> (Box<::std::error::Error + Send + 'static>,
-                                  Option<Option<::std::sync::Arc<$crate::Backtrace>>>) {
+                                  Option<$crate::BacktraceHolder>) {
             let mut backtrace = None;
 
             e = match e.downcast::<$error_name>() {
@@ -662,7 +657,6 @@ macro_rules! error_chain {
 
 use std::error::Error as StdError;
 use std::iter::Iterator;
-use std::sync::Arc;
 
 pub struct ErrorChainIter<'a>(pub Option<&'a StdError>);
 
@@ -680,18 +674,31 @@ impl<'a> Iterator for ErrorChainIter<'a> {
     }
 }
 
+/// Holds an optional backtrace (`backtrace` feature is on).
+#[cfg(feature="backtrace")]
+pub type BacktraceHolder = Option<::std::sync::Arc<backtrace::Backtrace>>;
+
+#[cfg(feature="backtrace")]
+pub use backtrace::Backtrace;
+
+/// Placeholder for backtrace information (`backtrace` feature is off).
+#[cfg(not(feature="backtrace"))]
+pub type BacktraceHolder = ();
+
+
 /// Returns a backtrace of the current call stack if `RUST_BACKTRACE`
 /// is set to anything but ``0``, and `None` otherwise.  This is used
 /// in the generated error implementations.
 #[cfg(feature = "backtrace")]
-pub fn make_backtrace() -> Option<Arc<Backtrace>> {
+pub fn make_backtrace() -> BacktraceHolder {
     match std::env::var_os("RUST_BACKTRACE") {
-        Some(ref val) if val != "0" => Some(Arc::new(Backtrace::new())),
+        Some(ref val) if val != "0" => Some(::std::sync::Arc::new(backtrace::Backtrace::new())),
         _ => None
     }
 }
 
+/// Noop implementation for make_backtrace (`backtrace` feature is off).
 #[cfg(not(feature = "backtrace"))]
-pub fn make_backtrace() -> Option<Arc<Backtrace>> {
-    None
+pub fn make_backtrace() -> BacktraceHolder {
+    ()
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -129,6 +129,7 @@ fn empty() {
     error_chain! { };
 }
 
+#[cfg(feature = "backtrace")]
 #[test]
 fn has_backtrace_depending_on_env() {
     use std::env;


### PR DESCRIPTION
Hey!

Thanks for this crate, it's a huge improvement over previous approaches.

I have one issue with it, though: it depends on backtrace, which does not cross-compile to ios (and possibly other exotic-ish platforms).

There are several approach to fix or workaround that. One (not necessarily my favorite) is shown in this PR. I just make backtrace support a feature and implement one dumb type placeholder and method to get rustc happy when backtrace is not provided.

One other option would be to get @alexcrichton on board with having backtrace cross compile to the platforms that he has so far excluded from support in backtrace (possibly using a similar noop placeholder in backtrace itself).

We could also use a platform detection instead of a feature to toggle backtrace on or off.

What do you think ?
