### PR TITLE
Add #[allow(missing_docs)] to the generated code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,12 +341,13 @@ macro_rules! error_chain {
         // This has a simple structure to support pattern matching
         // during error handling. The second field is internal state
         // that is mostly irrelevant for error handling purposes.
+        #[allow(missing_docs)]
         #[derive(Debug)]
         pub struct $error_name(pub $error_kind_name,
                                pub (Option<Box<::std::error::Error + Send>>,
                                     Option<::std::sync::Arc<$crate::Backtrace>>));
 
-        #[allow(unused)]
+        #[allow(unused, missing_docs)]
         impl $error_name {
             pub fn kind(&self) -> &$error_kind_name {
                 &self.0
@@ -434,6 +435,7 @@ macro_rules! error_chain {
         // --------------
 
         quick_error! {
+            #[allow(missing_docs)]
             #[derive(Debug)]
             pub enum $error_kind_name {
 
@@ -484,6 +486,7 @@ macro_rules! error_chain {
         // The ChainErr trait
         // ------------------
 
+        #[allow(missing_docs)]
         pub trait $chain_error_name<T> {
             fn chain_err<F, EK>(self, callback: F) -> ::std::result::Result<T, $error_name>
                 where F: FnOnce() -> EK,
@@ -542,6 +545,7 @@ macro_rules! error_chain {
         // The Result type
         // ---------------
 
+        #[allow(missing_docs)]
         pub type $result_name<T> = ::std::result::Result<T, $error_name>;
     };
 

--- a/src/quick_error.rs
+++ b/src/quick_error.rs
@@ -306,7 +306,7 @@ macro_rules! quick_error {
                 }
             }
         }*/
-        #[allow(unused)]
+        #[allow(unused, missing_docs)]
         impl $name {
             pub fn description(&self) -> &str {
                 match *self {


### PR DESCRIPTION
This enables users which don't have a separate module for errors (e.g. because they don't have that many) to use the macro in conjunction with `#![deny(missing_docs)]`.
