### PR TITLE
Allow conditional compilation for error variants.

### DIFF
--- a/src/quick_error.rs
+++ b/src/quick_error.rs
@@ -30,7 +30,7 @@ macro_rules! quick_error {
                       => $iitem: $imode [$( $ivar: $ityp ),*] )*]
         );
         quick_error!(IMPLEMENTATIONS $name {$(
-           $iitem: $imode [$( $ivar: $ityp ),*] {$( $ifuncs )*}
+           $iitem: $imode [$(#[$imeta])*] [$( $ivar: $ityp ),*] {$( $ifuncs )*}
            )*});
         $(
             quick_error!(ERROR_CHECK $imode $($ifuncs)*);
@@ -49,7 +49,7 @@ macro_rules! quick_error {
                       => $iitem: $imode [$( $ivar: $ityp ),*] )*]
         );
         quick_error!(IMPLEMENTATIONS $name {$(
-           $iitem: $imode [$( $ivar: $ityp ),*] {$( $ifuncs )*}
+           $iitem: $imode [$(#[$imeta])*] [$( $ivar: $ityp ),*] {$( $ifuncs )*}
            )*});
         $(
             quick_error!(ERROR_CHECK $imode $($ifuncs)*);
@@ -254,7 +254,7 @@ macro_rules! quick_error {
     };
     (IMPLEMENTATIONS
         $name:ident {$(
-            $item:ident: $imode:tt [$( $var:ident: $typ:ty ),*] {$( $funcs:tt )*}
+            $item:ident: $imode:tt [$(#[$imeta:meta])*] [$( $var:ident: $typ:ty ),*] {$( $funcs:tt )*}
         )*}
     ) => {
         #[allow(unused)]
@@ -264,6 +264,7 @@ macro_rules! quick_error {
             {
                 match *self {
                     $(
+                        $(#[$imeta])*
                         quick_error!(ITEM_PATTERN
                             $name $item: $imode [$( ref $var ),*]
                         ) => {
@@ -311,6 +312,7 @@ macro_rules! quick_error {
             pub fn description(&self) -> &str {
                 match *self {
                     $(
+                        $(#[$imeta])*
                         quick_error!(ITEM_PATTERN
                             $name $item: $imode [$( ref $var ),*]
                         ) => {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -253,3 +253,36 @@ mod foreign_link_test {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod attributes_test {
+    #[allow(unused_imports)]
+    use std::io;
+
+    mod inner {
+        error_chain! {
+
+        }
+    }
+
+    error_chain! {
+        types {
+            Error, ErrorKind, ErrorChain, Result;
+        }
+
+        links {
+            inner::Error, inner::ErrorKind, Inner, #[cfg(not(test))];
+        }
+
+        foreign_links {
+            io::Error, Io, #[cfg(not(test))];
+        }
+
+        errors {
+            #[cfg(not(test))]
+            AnError {
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
```rust
#[cfg(unix)]
io::Error, Io;
```
would be better than
```rust
io::Error, Io, #[cfg(unix)];
```
, but it confuses the macro parser: `local ambiguity: multiple parsing options: built-in NTs path (link_error_path) or 1 other option.`