### PR TITLE
Move code from the macro to the crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Conditional compilation for error variants.
 - Backtrace generation is now a feature.
 - More standard trait implementations for extra convenience.
+- Remove ChainErr.
+- Remove need to specify `ErrorKind` in `links {}`.
+- Add ResultExt trait.
 
 # 0.5.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -673,6 +673,7 @@ impl<'a> Iterator for ErrorChainIter<'a> {
 /// is set to anything but ``0``, and `None` otherwise.  This is used
 /// in the generated error implementations.
 #[cfg(feature = "backtrace")]
+#[doc(hidden)]
 pub fn make_backtrace() -> Option<Arc<Backtrace>> {
     match std::env::var_os("RUST_BACKTRACE") {
         Some(ref val) if val != "0" => Some(Arc::new(Backtrace::new())),
@@ -681,12 +682,13 @@ pub fn make_backtrace() -> Option<Arc<Backtrace>> {
 }
 
 #[cfg(not(feature = "backtrace"))]
+#[doc(hidden)]
 pub fn make_backtrace() -> Option<Arc<Backtrace>> {
     None
 }
 
-/// This trait is an implementation detail, you should have to implement or
-/// use it.
+/// This trait is an implementation detail which must be implemented on each
+/// ErrorKind. We can't do it globally since each ErrorKind is different.
 pub trait Error: error::Error + Send + 'static {
     /// Associated kind type.
     type ErrorKind;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,8 +135,8 @@
 //!     //
 //!     // This section can be empty.
 //!     links {
-//!         ::rustup_dist::Error, rustup_dist::ErrorKind, Dist;
-//!         ::rustup_utils::Error, rustup_utils::ErrorKind, Utils, #[cfg(unix)];
+//!         ::rustup_dist::Error, Dist;
+//!         ::rustup_utils::Error, Utils, #[cfg(unix)];
 //!     }
 //!
 //!     // Automatic conversions between this error chain and other
@@ -334,7 +334,7 @@ macro_rules! error_chain {
         }
 
         links {
-            $( $link_error_path:path, $link_kind_path:path, $link_variant:ident $(, #[$meta_links:meta])*; ) *
+            $( $link_error_path:path, $link_variant:ident $(, #[$meta_links:meta])*; ) *
         }
 
         foreign_links {
@@ -457,7 +457,7 @@ macro_rules! error_chain {
 
                 $(
                     $(#[$meta_links])*
-                    $link_variant(e: $link_kind_path) {
+                    $link_variant(e: <$link_error_path as $crate::Error>::ErrorKind) {
                         description(e.description())
                         display("{}", e)
                     }
@@ -477,8 +477,8 @@ macro_rules! error_chain {
 
         $(
             $(#[$meta_links])*
-            impl From<$link_kind_path> for $error_kind_name {
-                fn from(e: $link_kind_path) -> Self {
+            impl From<<$link_error_path as $crate::Error>::ErrorKind> for $error_kind_name {
+                fn from(e: <$link_error_path as $crate::Error>::ErrorKind) -> Self {
                     $error_kind_name::$link_variant(e)
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,6 +452,7 @@ macro_rules! error_chain {
         // --------------
 
         quick_error! {
+            /// The kind of an error
             #[derive(Debug)]
             pub enum $error_kind_name {
 
@@ -528,6 +529,7 @@ macro_rules! error_chain {
         // The Result type
         // ---------------
 
+        /// Convenient wrapper around std::Result.
         pub type $result_name<T> = ::std::result::Result<T, $error_name>;
     };
 

--- a/src/quick_error.rs
+++ b/src/quick_error.rs
@@ -309,6 +309,7 @@ macro_rules! quick_error {
         }*/
         #[allow(unused)]
         impl $name {
+            /// A string describing the error kind.
             pub fn description(&self) -> &str {
                 match *self {
                     $(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,7 +7,7 @@ extern crate error_chain;
 fn smoke_test_1() {
     error_chain! {
         types {
-            Error, ErrorKind, ChainErr, Result;
+            Error, ErrorKind, Result;
         }
 
         links { }
@@ -157,6 +157,15 @@ fn has_backtrace_depending_on_env() {
     assert!(err.backtrace().is_some());
 }
 
+#[test]
+fn chain_err() {
+    use error_chain::ResultExt;
+
+    error_chain! {}
+
+    let _: Result<()> = Err("".into()).chain_err(|| "");
+}
+
 #[cfg(test)]
 mod foreign_link_test {
 
@@ -202,7 +211,7 @@ mod foreign_link_test {
 
     error_chain! {
         types{
-            Error, ErrorKind, ChainErr, Result;
+            Error, ErrorKind, Result;
         }
         links {}
         foreign_links {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -166,6 +166,19 @@ fn chain_err() {
     let _: Result<()> = Err("".into()).chain_err(|| "");
 }
 
+#[test]
+fn links() {
+    mod test {
+        error_chain! {}
+    }
+
+    error_chain! {
+        links {
+            test::Error, Test;
+        }
+    }
+}
+
 #[cfg(test)]
 mod foreign_link_test {
 
@@ -277,11 +290,11 @@ mod attributes_test {
 
     error_chain! {
         types {
-            Error, ErrorKind, ErrorChain, Result;
+            Error, ErrorKind, Result;
         }
 
         links {
-            inner::Error, inner::ErrorKind, Inner, #[cfg(not(test))];
+            inner::Error, Inner, #[cfg(not(test))];
         }
 
         foreign_links {


### PR DESCRIPTION
Instead of creating one trait at each macro invocation, we create it one time in
this crate. Bonus point: the trait in visible in the doc of `error-chain`.

TODO:

- doc
- Better name for ChainErr (trait and enum)
- add tests for chain_err