### PR TITLE
Add a `bail!` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.7.0
 
+- [Add the `bail!` macro](https://github.com/brson/error-chain/pull/76)
 - [Rollback several design changes to fix regressions](https://github.com/brson/error-chain/pull/75)
 - New `Variant(Error) #[attrs]` for `links` and `foreign_links`.
 - Hide implementation details from the doc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,30 @@
 //! }
 //! ```
 //!
+//! ## The `bail!` early retun macro
+//!
+//! The above method of introducing new errors works but is a little
+//! verbose. Instead we can use the `bail!` macro, which, much like `try!`
+//! and `?`, performs an early return with conversions. With `bail!` the
+//! previous examples look like:
+//!
+//! ```
+//! # #[macro_use] extern crate error_chain;
+//! # fn main() {}
+//! # error_chain! { errors { FooError } }
+//! fn foo() -> Result<()> {
+//!     bail!(ErrorKind::FooError);
+//!
+//!     Ok(())
+//! }
+//!
+//! fn bar() -> Result<()> {
+//!     bail!("bogus!");
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
 //! ## Chaining errors
 //!
 //! To extend the error chain:
@@ -428,6 +452,82 @@ impl State {
         let b = None;
         b
     }
+}
+
+/// Exits a function early with an error
+///
+/// The `bail!` macro provides an easy way to exit a function.
+/// `bail!(expr)` is equivalent to writing.
+///
+/// ```
+/// # #[macro_use] extern crate error_chain;
+/// # error_chain! { }
+/// # fn main() { }
+/// # fn foo() -> Result<()> {
+/// # let expr = "";
+///     return Err(expr.into());
+/// # }
+/// ```
+///
+/// And as shorthand it takes a formatting string ala `println!`:
+///
+/// ```
+/// # #[macro_use] extern crate error_chain;
+/// # error_chain! { }
+/// # fn main() { }
+/// # fn foo() -> Result<()> {
+/// # let n = 0;
+/// bail!("bad number: {}", n);
+/// # }
+/// ```
+///
+/// # Examples
+///
+/// Bailing on a custom error:
+///
+/// ```
+/// # #[macro_use] extern crate error_chain;
+/// # fn main() {}
+/// error_chain! {
+///     errors { FooError }
+/// }
+///
+/// fn foo() -> Result<()> {
+///     if bad_condition() {
+///         bail!(ErrorKind::FooError);
+///     }
+///
+///     Ok(())
+/// }
+///
+/// # fn bad_condition() -> bool { true }
+/// ```
+///
+/// Bailing on a formatted string:
+///
+/// ```
+/// # #[macro_use] extern crate error_chain;
+/// # fn main() {}
+/// error_chain! { }
+///
+/// fn foo() -> Result<()> {
+///     if let Some(bad_num) = bad_condition() {
+///         bail!("so bad: {}", bad_num);
+///     }
+///
+///     Ok(())
+/// }
+///
+/// # fn bad_condition() -> Option<i8> { None }
+/// ```
+#[macro_export]
+macro_rules! bail {
+    ($e:expr) => {
+        return Err($e.into());
+    };
+    ($fmt:expr, $($arg:tt)+) => {
+        return Err(format!($fmt, $($arg)+).into());
+    };
 }
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,15 @@
 //! * Errors implement Send.
 //! * Errors can carry backtraces.
 //!
+//! ## Quick start
+//!
+//! If you just want to set up your new project with error-chain,
+//! follow the [quickstart.rs] template.
+//!
+//! [quickstart.rs]: https://github.com/brson/error-chain/blob/master/examples/quickstart.rs.
+//!
+//! ## error-chain design principles
+//!
 //! Similar to other libraries like [error-type] and [quick-error], this
 //! library defines a macro, `error_chain!` that declares the types
 //! and implementation boilerplate necessary for fulfilling a
@@ -55,10 +64,6 @@
 //!   to match.
 //! * Because the error type contains `std::error::Error + Send + 'static` objects,
 //!   it can't implement `PartialEq` for easy comparisons.
-//!
-//! ## Quick start
-//!
-//! See https://github.com/brson/error-chain/blob/master/examples/quickstart.rs.
 //!
 //! ## Declaring error types
 //!
@@ -191,7 +196,7 @@
 //! }
 //! ```
 //!
-//! ## The `bail!` early retun macro
+//! ## The `bail!` macro
 //!
 //! The above method of introducing new errors works but is a little
 //! verbose. Instead we can use the `bail!` macro, which, much like `try!`

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -504,3 +504,22 @@ fn error_first() {
         foreign_links { }
     }
 }
+
+#[test]
+fn bail() {
+    error_chain! {
+        errors { Foo }
+    }
+
+    fn foo() -> Result<()> {
+        Ok(bail!(ErrorKind::Foo))
+    }
+
+    fn bar() -> Result<()> {
+        Ok(bail!("bar"))
+    }
+
+    fn baz() -> Result<()> {
+        Ok(bail!("{}", "baz"))
+    }
+}


### PR DESCRIPTION
This macro is similar to cargo's `bail!` and to the `throw` keyword originally proposed as part of the exception handling RFC. It's just a shorthand for early return with coercion.

I'm inclined to land this quick to sweeten up today's 0.7.0 release.

cc @Yamakaky @nikomatsakis