### PR TITLE
docs: fix link to quickstart.rs example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! follow the [quickstart.rs] template, and read this [intro]
 //! to error-chain.
 //!
-//! [quickstart.rs]: https://github.com/brson/error-chain/blob/master/examples/quickstart.rs.
+//! [quickstart.rs]: https://github.com/brson/error-chain/blob/master/examples/quickstart.rs
 //! [intro]: http://brson.github.io/2016/11/30/starting-with-error-chain
 //!
 //! ## error-chain design principles


### PR DESCRIPTION
Remove extraneous dot at end of link.

Signed-off-by: Andrew Donnellan <andrew@donnellan.id.au>