### PR TITLE
README.md: fix link to quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you just want to set up your new project with error-chain,
 follow the [quickstart.rs] template, and read this [intro]
 to error-chain.
 
-[quickstart.rs]: https://github.com/brson/error-chain/blob/master/examples/quickstart.rs.
+[quickstart.rs]: https://github.com/brson/error-chain/blob/master/examples/quickstart.rs
 [intro]: http://brson.github.io/2016/11/30/starting-with-error-chain
 
 ## License


### PR DESCRIPTION
Same fix as 5d4114a56185 ("docs: fix link to quickstart.rs example").

Signed-off-by: Andrew Donnellan <andrew@donnellan.id.au>