### PR TITLE
Add a .chain_main() helper to implement main() in terms of real_main()

### DIFF
--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -13,34 +13,26 @@ extern crate error_chain;
 // this crate will `use errors::*;` to get access to everything
 // `error_chain!` creates.
 mod errors {
-    // Create the Error, ErrorKind, ResultExt, and Result types
+    // Create the Error, ErrorKind, ResultExt, Result, and ChainMain types
     error_chain! { }
 }
 
 use errors::*;
 
 fn main() {
-    if let Err(ref e) = run() {
-        println!("error: {}", e);
-
-        for e in e.iter().skip(1) {
-            println!("caused by: {}", e);
-        }
-
-        // The backtrace is not always generated. Try to run this example
-        // with `RUST_BACKTRACE=1`.
-        if let Some(backtrace) = e.backtrace() {
-            println!("backtrace: {:?}", backtrace);
-        }
-
-        ::std::process::exit(1);
-    }
+    // The backtrace is not always generated. Try to run this example
+    // with `RUST_BACKTRACE=1`.
+    real_main().chain_main()
 }
 
 // Most functions will return the `Result` type, imported from the
 // `errors` module. It is a typedef of the standard `Result` type
 // for which the error type is always our own `Error`.
-fn run() -> Result<()> {
+//
+// real_main() can also return Result<i32> to provide a non-zero
+// exit code in the "success" case, such as for a grep-like program
+// returning 1 if no match.
+fn real_main() -> Result<()> {
     use std::fs::File;
 
     // This operation will fail

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,10 +110,10 @@
 //!     // It is also possible to leave this block out entirely, or
 //!     // leave it empty, and these names will be used automatically.
 //!     types {
-//!         Error, ErrorKind, ResultExt, Result;
+//!         Error, ErrorKind, ResultExt, Result, ChainMain;
 //!     }
 //!
-//!     // Without the `Result` wrapper:
+//!     // Without the `Result` and `ChainMain` wrappers:
 //!     //
 //!     // types {
 //!     //     Error, ErrorKind, ResultExt;
@@ -358,7 +358,21 @@
 //!
 //! [error-type]: https://github.com/DanielKeep/rust-error-type
 //! [quick-error]: https://github.com/tailhook/quick-error
-
+//!
+//! ## Writing `main()`
+//!
+//! The `ChainMain` helper trait provides a `chain_main()` method that makes it
+//! easy to define your `main()` function in terms of a `real_main()` returning
+//! a `Result`. This allows you to use `try!`, `?`, or `bail!` in `real_main()`.
+//! On error, `real_main().chain_main()` will print the error chain (and
+//! backtrace with `RUST_BACKTRACE=1`), and call `::std::process::exit(1)`.
+//!
+//! `real_main()` can return `Result<()>`, in which case
+//! `real_main().chain_main()` will exit with 0 on success. Or, `real_main()`
+//! can return `Result<i32>`, in which case `real_main().chain_main()` will exit
+//! with that value on success; this simplifies the implementation of programs
+//! like grep that indicate something more than an error with their exit code,
+//! such as not finding any matches.
 
 #[cfg(feature = "backtrace")]
 extern crate backtrace;


### PR DESCRIPTION
Generate a trait with the default name ChainMain, providing a method
.chain_main() that checks for an error, prints it (and its full chain
and possible backtrace), and exits with an appropriate exit code.