### PR TITLE
examples/all.rs: Fix typo in type name

### DIFF
--- a/examples/all.rs
+++ b/examples/all.rs
@@ -24,7 +24,7 @@ error_chain! {
     links {
         Inner(inner::Error, inner::ErrorKind);
         // Attributes can be added at the end of the declaration.
-        Feature(feature::Error, feature::Error) #[cfg(feature = "a_feature")];
+        Feature(feature::Error, feature::ErrorKind) #[cfg(feature = "a_feature")];
     }
 
     // Bindings to types implementing std::error::Error.


### PR DESCRIPTION
Part of the example used feature::Error instead of feature::ErrorKind,
which would have caused it to fail to compile if not for the fake
feature disabling it.