### PR TITLE
Make error_chain with default-features = false work with Rust 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ rust:
 - stable
 - beta
 - nightly
-# Oldest supported version.
+# Oldest supported version for all features.
 # Use of https://github.com/rust-lang/rfcs/pull/16
 - 1.13.0
+# Oldest supported version as dependency, with no features, tests, or examples.
+- 1.10.0
 
 sudo: false
 cache: cargo
@@ -22,8 +24,8 @@ before_script:
   export PATH=$HOME/.local/bin:$PATH
 
 script:
-- cargo build --verbose $FEATURES
-- cargo test --verbose $FEATURES
+- travis-cargo build -- $FEATURES
+- travis-cargo --skip 1.10.0 test -- $FEATURES
 
 after_success:
 - travis-cargo --only stable doc
@@ -32,6 +34,12 @@ after_success:
 env:
   global:
   - secure: ncxJbvJM1vCZfcEftjsFKJMxxhKLgWKaR8Go9AMo0VB5fB2XVW/6NYO5bQEEYpOf1Nc/+2FbI2+Dkz0S/mJpUcNSfBgablCHgwU2sHse7KsoaqfHj2mf1E3exjzSHoP96hPGicC5zAjSXFjCgJPOUSGqqRaJ7z5AsJLhJT6LuK7QpvwPBZzklUN8T+n1sVmws8TNmRIbaniq/q6wYHANHcy6Dl59dx4sKwniUGiZdUhCiddVpoxbECSxc0A8mN2pk7/aW+WGxK3goBs5ZF7+JXF318F62pDcXQmR5CX6WdpenIcJ25g1Vg1WhQ4Ifpe17CN0bfxV8ShuzrQUThCDMffZCo9XySBtODdEowwK1UIpjnFLfIxjOs45Cd8o3tM2j0CfvtnjOz6BCdUU0qiwNPPNx0wFkx3ZiOfSh+FhBhvyPM12HN2tdN0esgVBItFmEci+sSIIXqjVL6DNiu5zTjbu0bs6COwlUWdmL6vmsZtq5tl7Cno9+C3szxRVAkShGydd04l9NYjqNEzTa1EPG50OsnVRKGdRiFzSxhc3BWExNKvcQ4v867t6/PpPkW6s4oXmYI3+De+8O7ExWc6a4alcrDXKlMs5fCb5Pcd4Ju9kowcjkoJo5yf2wW3Ox5R8SJpaEEpvyhx5O/qtIxjhHNzeo8Wsr/6gdNDv20r91TI=
+  - TRAVIS_CARGO_NIGHTLY_FEATURE=""
   matrix:
   - FEATURES=--features=backtrace
   - FEATURES=--no-default-features
+
+matrix:
+  exclude:
+  - env: FEATURES=--features=backtrace
+    rust: 1.10.0

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ to error-chain.
 Please view the beginning of the [Travis configuration file](.travis.yml)
 to see the oldest supported Rust version.
 
+Note that `error-chain` supports older versions of Rust when built with
+`default-features = false`.
+
 ## License
 
 MIT/Apache-2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,42 +455,47 @@ pub struct State {
 }
 
 impl Default for State {
+    #[cfg(feature = "backtrace")]
     fn default() -> State {
-        #[cfg(feature = "backtrace")]
-        let state = State {
+        State {
             next_error: None,
             backtrace: make_backtrace(),
-        };
-        #[cfg(not(feature = "backtrace"))]
-        let state = State { next_error: None };
-        state
+        }
+    }
+
+    #[cfg(not(feature = "backtrace"))]
+    fn default() -> State {
+        State { next_error: None }
     }
 }
 
 impl State {
     /// Creates a new State type
+    #[cfg(feature = "backtrace")]
     pub fn new<CE: ChainedError>(e: Box<error::Error + Send>) -> State {
-        #[cfg(feature = "backtrace")]
-        let state = {
-            let backtrace = CE::extract_backtrace(&*e).or_else(make_backtrace);
-            State {
-                next_error: Some(e),
-                backtrace: backtrace,
-            }
-        };
-        #[cfg(not(feature = "backtrace"))]
-        let state = State { next_error: Some(e) };
+        let backtrace = CE::extract_backtrace(&*e).or_else(make_backtrace);
+        State {
+            next_error: Some(e),
+            backtrace: backtrace,
+        }
+    }
 
-        state
+    /// Creates a new State type
+    #[cfg(not(feature = "backtrace"))]
+    pub fn new<CE: ChainedError>(e: Box<error::Error + Send>) -> State {
+        State { next_error: Some(e) }
     }
 
     /// Returns the inner backtrace if present.
+    #[cfg(feature = "backtrace")]
     pub fn backtrace(&self) -> Option<&Backtrace> {
-        #[cfg(feature = "backtrace")]
-        let b = self.backtrace.as_ref().map(|v| &**v);
-        #[cfg(not(feature = "backtrace"))]
-        let b = None;
-        b
+        self.backtrace.as_ref().map(|v| &**v)
+    }
+
+    /// Returns the inner backtrace if present.
+    #[cfg(not(feature = "backtrace"))]
+    pub fn backtrace(&self) -> Option<&Backtrace> {
+        None
     }
 }
 


### PR DESCRIPTION
error_chain uses attributes on statements, stablized in Rust 1.13.
Factor them out of functions in the non-backtrace codepath, making it
possible to build a crate that uses error_chain with Rust 1.10.

The backtrace feature still requires Rust 1.13 for attributes on
statements, due to the impl_extract_backtrace macro, which needs to emit
a function with one block for each linked error type, some of which may
have attributes on them.  And any code using compile-time conditionals
in attributes on variants within an error_chain! invocation (which
includes many of the tests and examples) will produce an error due to
https://github.com/rust-lang/rust/issues/22250 (fixed in Rust 1.11).
But a crate using error_chain with default-features = false and avoiding
such compile-time conditionals will now compile.