### PR TITLE
Clarify the documentation on the generated Error type and unhide ErrorKind element

### DIFF
--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -56,16 +56,17 @@ macro_rules! error_chain_processed {
     ) => {
         /// The Error type.
         ///
-        /// This struct is made of three things:
+        /// This tuple struct is made of two elements:
         ///
         /// - an `ErrorKind` which is used to determine the type of the error.
-        /// - a backtrace, generated when the error is created.
-        /// - an error chain, used for the implementation of `Error::cause()`.
+        /// - An internal `State`, not meant for direct use outside of `error_chain`
+        ///   internals, containing:
+        ///   - a backtrace, generated when the error is created.
+        ///   - an error chain, used for the implementation of `Error::cause()`.
         #[derive(Debug)]
         pub struct $error_name(
             // The members must be `pub` for `links`.
             /// The kind of the error.
-            #[doc(hidden)]
             pub $error_kind_name,
             /// Contains the error chain and the backtrace.
             #[doc(hidden)]


### PR DESCRIPTION
It's a bit odd that this tuple struct has:

* Documentation hidden on a member where the underlying type is not hidden.
* Number of elements and documentation count a bit off as when it was
  hidden there were *two* hidden elements in the tuple struct signature
  but the documentation text says there are *three* things in the
  `Error`?
* The first hidden element of the tuple struct is used prominently in
  the `lib.rs` documentation for pattern matching nested errors but it's
  hidden. If it's to be consumed by users, documentation on it should
  probably not be hidden. The `Error` tuple struct should be less opaque
  here.