### PR TITLE
Add a method to format chained errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [Add a `Sync` bound to errors](https://github.com/brson/error-chain/pul/110)
+- [Add `ChainedError::display` to format error chains](https://github.com/brson/error-chain/pull/113)
 
 # 0.7.2
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,7 @@ pub trait ChainedError: error::Error + Sync + Send + 'static {
 }
 
 /// A struct which formats an error for output.
+#[derive(Debug)]
 pub struct Display<'a, T: 'a + ?Sized>(&'a T);
 
 impl<'a, T> fmt::Display for Display<'a, T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,9 +437,7 @@ pub trait ChainedError: error::Error + Sync + Send + 'static {
     /// context of this error.
     ///
     /// The full cause chain and backtrace, if present, will be printed.
-    fn display<'a>(&'a self) -> Display<'a, Self>
-        where Self: Sized
-    {
+    fn display<'a>(&'a self) -> Display<'a, Self> {
         Display(self)
     }
 
@@ -456,7 +454,7 @@ pub trait ChainedError: error::Error + Sync + Send + 'static {
 }
 
 /// A struct which formats an error for output.
-pub struct Display<'a, T: 'a>(&'a T);
+pub struct Display<'a, T: 'a + ?Sized>(&'a T);
 
 impl<'a, T> fmt::Display for Display<'a, T>
     where T: ChainedError

--- a/src/quick_main.rs
+++ b/src/quick_main.rs
@@ -37,13 +37,12 @@ macro_rules! quick_main {
     ($main:expr) => {
         fn main() {
             use ::std::io::Write;
-            let stderr = &mut ::std::io::stderr();
-            let errmsg = "Error writing to stderr";
 
             ::std::process::exit(match $main() {
                 Ok(ret) => $crate::ExitCode::code(ret),
                 Err(ref e) => {
-                    write!(stderr, "{}", $crate::ChainedError::display(e)).expect(errmsg);
+                    write!(&mut ::std::io::stderr(), "{}", $crate::ChainedError::display(e))
+                        .expect("Error writing to stderr");
 
                     1
                 }

--- a/src/quick_main.rs
+++ b/src/quick_main.rs
@@ -43,16 +43,7 @@ macro_rules! quick_main {
             ::std::process::exit(match $main() {
                 Ok(ret) => $crate::ExitCode::code(ret),
                 Err(ref e) => {
-                    let e: &$crate::ChainedError<ErrorKind=_> = e;
-                    writeln!(stderr, "Error: {}", e).expect(errmsg);
-
-                    for e in e.iter().skip(1) {
-                        writeln!(stderr, "Caused by: {}", e).expect(errmsg);
-                    }
-
-                    if let Some(backtrace) = e.backtrace() {
-                        writeln!(stderr, "{:?}", backtrace).expect(errmsg);
-                    }
+                    write!(stderr, "{}", $crate::ChainedError::display(e)).expect(errmsg);
 
                     1
                 }


### PR DESCRIPTION
The main function isn't the only place you might want to print the full
error message, for example, to log error messages produced by a handler
in a web server.