### PR TITLE
Implemented a new constructor for Error: from_err()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [Add a new constructor for `Error`: `with_chain`.](https://github.com/brson/error-chain/pull/126)
+
 # 0.9.0
 
 - Revert [Add a `Sync` bound to errors](https://github.com/brson/error-chain/pul/110)

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -84,8 +84,8 @@ macro_rules! error_chain_processed {
                 Self::from_kind(kind)
             }
 
-            fn from_err<E: ::std::error::Error + Send + 'static>(error: E, kind: Self::ErrorKind) -> Self {
-                Self::from_err(error, kind)
+            fn with_chain<E: ::std::error::Error + Send + 'static, K: Into<Self::ErrorKind>>(error: E, kind: K) -> Self {
+                Self::with_chain(error, kind)
             }
 
             fn kind(&self) -> &Self::ErrorKind {
@@ -116,9 +116,9 @@ macro_rules! error_chain_processed {
             }
 
             /// Constructs a chained error from another error and a kind, and generates a backtrace.
-            pub fn from_err<E: ::std::error::Error + Send + 'static>(error: E, kind: $error_kind_name) -> $error_name {
+            pub fn with_chain<E: ::std::error::Error + Send + 'static, K: Into<$error_kind_name>>(error: E, kind: K) -> $error_name {
                 $error_name(
-                    kind,
+                    kind.into(),
                     $crate::State::new::<$error_name>(Box::new(error), ),
                 )
             }

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -84,6 +84,10 @@ macro_rules! error_chain_processed {
                 Self::from_kind(kind)
             }
 
+            fn from_err<E: ::std::error::Error + Send + 'static>(error: E, kind: Self::ErrorKind) -> Self {
+                Self::from_err(error, kind)
+            }
+
             fn kind(&self) -> &Self::ErrorKind {
                 self.kind()
             }
@@ -108,6 +112,14 @@ macro_rules! error_chain_processed {
                 $error_name(
                     kind,
                     $crate::State::default(),
+                )
+            }
+
+            /// Constructs a chained error from another error and a kind, and generates a backtrace.
+            pub fn from_err<E: ::std::error::Error + Send + 'static>(error: E, kind: $error_kind_name) -> $error_name {
+                $error_name(
+                    kind,
+                    $crate::State::new::<$error_name>(Box::new(error), ),
                 )
             }
 

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -84,7 +84,11 @@ macro_rules! error_chain_processed {
                 Self::from_kind(kind)
             }
 
-            fn with_chain<E: ::std::error::Error + Send + 'static, K: Into<Self::ErrorKind>>(error: E, kind: K) -> Self {
+            fn with_chain<E, K>(error: E, kind: K)
+                -> Self
+                where E: ::std::error::Error + Send + 'static,
+                      K: Into<Self::ErrorKind>
+            {
                 Self::with_chain(error, kind)
             }
 
@@ -116,7 +120,11 @@ macro_rules! error_chain_processed {
             }
 
             /// Constructs a chained error from another error and a kind, and generates a backtrace.
-            pub fn with_chain<E: ::std::error::Error + Send + 'static, K: Into<$error_kind_name>>(error: E, kind: K) -> $error_name {
+            pub fn with_chain<E, K>(error: E, kind: K)
+                -> $error_name
+                where E: ::std::error::Error + Send + 'static,
+                      K: Into<$error_kind_name>
+            {
                 $error_name(
                     kind.into(),
                     $crate::State::new::<$error_name>(Box::new(error), ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,10 @@ pub trait ChainedError: error::Error + Send + 'static {
     fn from_kind(kind: Self::ErrorKind) -> Self where Self: Sized;
 
     /// Constructs a chained error from another error and a kind, and generates a backtrace.
-    fn with_chain<E: ::std::error::Error + Send + 'static, K: Into<Self::ErrorKind>>(error: E, kind: K) -> Self where Self: Sized;
+    fn with_chain<E, K>(error: E, kind: K) -> Self
+        where Self: Sized,
+              E: ::std::error::Error + Send + 'static,
+              K: Into<Self::ErrorKind>;
 
     /// Returns the kind of the error.
     fn kind(&self) -> &Self::ErrorKind;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,7 @@ pub trait ChainedError: error::Error + Send + 'static {
     fn from_kind(kind: Self::ErrorKind) -> Self where Self: Sized;
 
     /// Constructs a chained error from another error and a kind, and generates a backtrace.
-    fn from_err<E: ::std::error::Error + Send + 'static>(error: E, kind: Self::ErrorKind) -> Self where Self: Sized;
+    fn with_chain<E: ::std::error::Error + Send + 'static, K: Into<Self::ErrorKind>>(error: E, kind: K) -> Self where Self: Sized;
 
     /// Returns the kind of the error.
     fn kind(&self) -> &Self::ErrorKind;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,9 @@ pub trait ChainedError: error::Error + Send + 'static {
     /// Constructs an error from a kind, and generates a backtrace.
     fn from_kind(kind: Self::ErrorKind) -> Self where Self: Sized;
 
+    /// Constructs a chained error from another error and a kind, and generates a backtrace.
+    fn from_err<E: ::std::error::Error + Send + 'static>(error: E, kind: Self::ErrorKind) -> Self where Self: Sized;
+
     /// Returns the kind of the error.
     fn kind(&self) -> &Self::ErrorKind;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -541,3 +541,40 @@ fn types_declarations() {
 
     let _: MyResult<()> = Ok(());
 }
+
+#[test]
+/// Calling chain_err over a `Result` containing an error to get a chained error
+//// and constructing a MyError directly, passing it an error should be equivalent.
+fn rewrapping() {
+
+    use std::env::VarError::{self, NotPresent, NotUnicode};
+
+    error_chain! {
+        foreign_links {
+            VarErr(VarError);
+        }
+
+        types {
+            MyError, MyErrorKind, MyResultExt, MyResult;
+        }
+    }
+
+    let result_a_from_func: Result<String, _> = Err(VarError::NotPresent);
+    let result_b_from_func: Result<String, _> = Err(VarError::NotPresent);
+
+    let our_error_a = result_a_from_func.map_err(|e| match e {
+        NotPresent => MyError::from_err(e, "env var wasn't provided".into()),
+        NotUnicode(_) => MyError::from_err(e, "env var was borkæ–‡å­—åŒ–ã".into()),
+    });
+
+    let our_error_b = result_b_from_func.or_else(|e| match e {
+        NotPresent => Err(e).chain_err(|| "env var wasn't provided"),
+        NotUnicode(_) => Err(e).chain_err(|| "env var was borkæ–‡å­—åŒ–ã"),
+    });
+
+    assert_eq!(
+        format!("{}", our_error_a.unwrap_err()),
+        format!("{}", our_error_b.unwrap_err())
+    );
+
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -563,8 +563,8 @@ fn rewrapping() {
     let result_b_from_func: Result<String, _> = Err(VarError::NotPresent);
 
     let our_error_a = result_a_from_func.map_err(|e| match e {
-        NotPresent => MyError::from_err(e, "env var wasn't provided".into()),
-        NotUnicode(_) => MyError::from_err(e, "env var was borkæ–‡å­—åŒ–ã".into()),
+        NotPresent => MyError::with_chain(e, "env var wasn't provided"),
+        NotUnicode(_) => MyError::with_chain(e, "env var was borkæ–‡å­—åŒ–ã"),
     });
 
     let our_error_b = result_b_from_func.or_else(|e| match e {


### PR DESCRIPTION
from_err() chains another error as the cause of Error.

Another thing to consider is that currently the `Error::from_kind()` and `Error::form_err()` constructors take the kind directly. Since this is a ergonomics-oriented library, it might be reasonable to take `Into<ErrorKind>`? What do you think? Or will it cause inference problems again?