### PR TITLE
Add ensure! convenience macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [Add a new constructor for `Error`: `with_chain`.](https://github.com/brson/error-chain/pull/126)
+- [Add the `ensure!` macro.](https://github.com/brson/error-chain/pull/135)
 
 # 0.9.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -617,6 +617,42 @@ macro_rules! bail {
     };
 }
 
+/// Exits a function early with an error if the condition is not satisfied
+///
+/// The `ensure!` macro is a convenience helper that provides a way to exit
+/// a function with an error if the given condition fails.
+///
+/// As an example, `ensure!(condition, "error code: {}", errcode)` is equivalent to
+///
+/// ```
+/// # #[macro_use] extern crate error_chain;
+/// # error_chain! { }
+/// # fn main() { }
+/// # fn foo() -> Result<()> {
+/// # let errcode = 0u8;
+/// # let condition = true;
+/// if !condition {
+///     bail!("error code: {}", errcode);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// See documentation for `bail!` macro for further details.
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $e:expr) => {
+        if !($cond) {
+            bail!($e);
+        }
+    };
+    ($cond:expr, $fmt:expr, $($arg:tt)+) => {
+        if !($cond) {
+            bail!($fmt, $($arg)+);
+        }
+    };
+}
+
 #[doc(hidden)]
 pub mod mock {
     error_chain!{}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -524,6 +524,21 @@ fn bail() {
     }
 }
 
+#[test]
+fn ensure() {
+    error_chain! {
+        errors { Bar }
+    }
+
+    fn foo(x: u8) -> Result<()> {
+        ensure!(x == 42, ErrorKind::Bar);
+        Ok(())
+    }
+
+    assert!(foo(42).is_ok());
+    assert!(foo(0).is_err());
+}
+
 /// Since the `types` declaration is a list of symbols, check if we
 /// don't change their meaning or order.
 #[test]


### PR DESCRIPTION
This is quite trivial but is something I found myself defining in most of my crates (because you would always have some sort of kind of if-condition for `bail!` and quite often this condition is a trivial expression that does not affect the error kind/message, particularly so in i/o heavy blocks; less typing, less braces and less rightward-drift = win), so I figured I'd share as I think it fits the spirit of this crate quite well.

Basically,

```rust
ensure!(ultimate_answer == 42, "some {}", "error");
```