### PR TITLE
Allow , after description/display/... in errors section

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,13 @@
 //!             description("invalid toolchain name")
 //!             display("invalid toolchain name: '{}'", t)
 //!         }
+//!
+//!         // You can also add commas after description/display.
+//!         // This may work better with some editor auto-identation modes:
+//!         UnknownToolchainVersion(v: String) {
+//!             description("unknown toolchain version"), // note the ,
+//!             display("unknown toolchain version: '{}'", v), // trailing comma is allowed
+//!         }
 //!     }
 //! }
 //!

--- a/src/quick_error.rs
+++ b/src/quick_error.rs
@@ -506,24 +506,28 @@ macro_rules! quick_error {
     // This is to contrast FIND_* clauses which just find stuff they need and
     // skip everything else completely
     (ERROR_CHECK $imode:tt display($self_:tt) -> ($( $exprs:tt )*) $( $tail:tt )*)
-    => { quick_error!(ERROR_CHECK $imode $($tail)*); };
+    => { quick_error!(ERROR_CHECK_COMMA $imode $($tail)*); };
     (ERROR_CHECK $imode:tt display($pattern: expr) $( $tail:tt )*)
-    => { quick_error!(ERROR_CHECK $imode $($tail)*); };
+    => { quick_error!(ERROR_CHECK_COMMA $imode $($tail)*); };
     (ERROR_CHECK $imode:tt display($pattern: expr, $( $exprs:tt )*) $( $tail:tt )*)
-    => { quick_error!(ERROR_CHECK $imode $($tail)*); };
+    => { quick_error!(ERROR_CHECK_COMMA $imode $($tail)*); };
     (ERROR_CHECK $imode:tt description($expr:expr) $( $tail:tt )*)
-    => { quick_error!(ERROR_CHECK $imode $($tail)*); };
+    => { quick_error!(ERROR_CHECK_COMMA $imode $($tail)*); };
     (ERROR_CHECK $imode:tt cause($expr:expr) $($tail:tt)*)
-    => { quick_error!(ERROR_CHECK $imode $($tail)*); };
+    => { quick_error!(ERROR_CHECK_COMMA $imode $($tail)*); };
     (ERROR_CHECK $imode:tt from() $($tail:tt)*)
-    => { quick_error!(ERROR_CHECK $imode $($tail)*); };
+    => { quick_error!(ERROR_CHECK_COMMA $imode $($tail)*); };
     (ERROR_CHECK $imode:tt from($ftyp:ty) $($tail:tt)*)
-    => { quick_error!(ERROR_CHECK $imode $($tail)*); };
+    => { quick_error!(ERROR_CHECK_COMMA $imode $($tail)*); };
     (ERROR_CHECK TUPLE from($fvar:ident: $ftyp:ty) -> ($( $e:expr ),*) $( $tail:tt )*)
-    => { quick_error!(ERROR_CHECK TUPLE $($tail)*); };
+    => { quick_error!(ERROR_CHECK_COMMA TUPLE $($tail)*); };
     (ERROR_CHECK STRUCT from($fvar:ident: $ftyp:ty) -> {$( $v:ident: $e:expr ),*} $( $tail:tt )*)
-    => { quick_error!(ERROR_CHECK STRUCT $($tail)*); };
+        => { quick_error!(ERROR_CHECK_COMMA STRUCT $($tail)*); };
     (ERROR_CHECK $imode:tt ) => {};
+    (ERROR_CHECK_COMMA $imode:tt , $( $tail:tt )*)
+    => { quick_error!(ERROR_CHECK $imode $($tail)*); };
+    (ERROR_CHECK_COMMA $imode:tt $( $tail:tt )*)
+    => { quick_error!(ERROR_CHECK $imode $($tail)*); };
     // Utility functions
     (IDENT $ident:ident) => { $ident }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -593,3 +593,36 @@ fn rewrapping() {
     );
 
 }
+
+#[test]
+fn comma_in_errors_impl() {
+    error_chain! {
+        links { }
+
+        foreign_links { }
+
+        errors {
+            HttpStatus(e: u32) {
+                description("http request returned an unsuccessful status code"),
+                display("http request returned an unsuccessful status code: {}", e)
+            }
+        }
+    };
+}
+
+
+#[test]
+fn trailing_comma_in_errors_impl() {
+    error_chain! {
+        links { }
+
+        foreign_links { }
+
+        errors {
+            HttpStatus(e: u32) {
+                description("http request returned an unsuccessful status code"),
+                display("http request returned an unsuccessful status code: {}", e),
+            }
+        }
+    };
+}


### PR DESCRIPTION
This allows the following code to compile:

```
error_chain! {
    links { }

    foreign_links { }

    errors {
        HttpStatus(e: u32) {
            description("http request returned an unsuccessful status code"),
            display("http request returned an unsuccessful status code: {}", e),
        }
    }
};
```

(Note the comma after `description` and `display`)

This plays nicer with identation in at least the Emacs editor (and I think it should be easier to deal with for other editors as well)
