### PR TITLE
Add "Inspecting errors" section to top-level docs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,7 @@
 //! }
 //!
 //! # fn main() {
+//! // Generate an example error to inspect:
 //! let e = "xyzzy".parse::<i32>()
 //!     .chain_err(|| ErrorKind::InvalidToolchainName("xyzzy".to_string()))
 //!     .unwrap_err();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,8 +402,9 @@
 //! }
 //!
 //! # fn main() {
-//! let cause = "xyzzy".parse::<i32>().err().unwrap();
-//! let e = Error::with_chain(cause, ErrorKind::InvalidToolchainName("xyzzy".to_string()));
+//! let e = "xyzzy".parse::<i32>()
+//!     .chain_err(|| ErrorKind::InvalidToolchainName("xyzzy".to_string()))
+//!     .unwrap_err();
 //!
 //! // Get the brief description of the error:
 //! assert_eq!(e.description(), "invalid toolchain name");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,6 +383,51 @@
 //! # }
 //! ```
 //!
+//! ## Inspecting errors
+//!
+//! An error-chain error contains information about the error itself, a backtrace, and the chain
+//! of causing errors. For reporting purposes, this information can be accessed as follows.
+//!
+//! ```
+//! # #[macro_use] extern crate error_chain;
+//! use error_chain::ChainedError;  // for e.display()
+//!
+//! error_chain! {
+//!     errors {
+//!         InvalidToolchainName(t: String) {
+//!             description("invalid toolchain name")
+//!             display("invalid toolchain name: '{}'", t)
+//!         }
+//!     }
+//! }
+//!
+//! # fn main() {
+//! let cause = "xyzzy".parse::<i32>().err().unwrap();
+//! let e = Error::with_chain(cause, ErrorKind::InvalidToolchainName("xyzzy".to_string()));
+//!
+//! // Get the brief description of the error:
+//! assert_eq!(e.description(), "invalid toolchain name");
+//!
+//! // Get the display version of the error:
+//! assert_eq!(e.to_string(), "invalid toolchain name: 'xyzzy'");
+//!
+//! // Get the full cause and backtrace:
+//! println!("{}", e.display().to_string());
+//! //     Error: invalid toolchain name: 'xyzzy'
+//! //     Caused by: invalid digit found in string
+//! //     stack backtrace:
+//! //        0:     0x7fa9f684fc94 - backtrace::backtrace::libunwind::trace
+//! //                             at src/backtrace/libunwind.rs:53
+//! //                              - backtrace::backtrace::trace<closure>
+//! //                             at src/backtrace/mod.rs:42
+//! //        1:     0x7fa9f6850b0e - backtrace::capture::{{impl}}::new
+//! //                             at out/capture.rs:79
+//! //     [..]
+//! # }
+//! ```
+//!
+//! The `Error` and `ErrorKind` types also allow programmatic access to these elements.
+//!
 //! ## Foreign links
 //!
 //! Errors that do not conform to the same conventions as this library


### PR DESCRIPTION
Hi - another proposed addition to the documentation, based on experience with our developers here. This is just a new section in the top-level docs, explaining how to get at the display, description, and backtrace of an error in your code.

Are you happy to add this? I know some of this is not error-chain-specific, but it seems like useful information alongside the other info on how to use the crate.

Thanks.